### PR TITLE
Add aliases to "create" and "delete" commands

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -36,7 +37,6 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -345,9 +345,10 @@ func main() {
 		UsageText: "terracreds create -n api.terraform.com -t sampleApiTokenString",
 		Version:   version,
 		Commands: []*cli.Command{
-			&cli.Command{
-				Name:  "create",
-				Usage: "Create or update a credential object in the local operating sytem's credential manager that contains the Terraform Cloud/Enterprise authorization token",
+			{
+				Name:    "create",
+				Aliases: []string{"store"},
+				Usage:   "Create or update a credential object in the local operating sytem's credential manager that contains the Terraform Cloud/Enterprise authorization token",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:    "hostname",
@@ -371,9 +372,10 @@ func main() {
 					return nil
 				},
 			},
-			&cli.Command{
-				Name:  "delete",
-				Usage: "Delete a credential stored in the local operating system's credential manager",
+			{
+				Name:    "delete",
+				Aliases: []string{"forget"},
+				Usage:   "Delete a credential stored in the local operating system's credential manager",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:    "hostname",
@@ -399,7 +401,7 @@ func main() {
 					return nil
 				},
 			},
-			&cli.Command{
+			{
 				Name:  "generate",
 				Usage: "Generate the folders and plugin binary required to leverage terracreds as a Terraform credential helper",
 				Flags: []cli.Flag{
@@ -419,7 +421,7 @@ func main() {
 					return nil
 				},
 			},
-			&cli.Command{
+			{
 				Name:  "get",
 				Usage: "Get the credential object value by passing the hostname of the Terraform Cloud/Enterprise server as an argument. The credential is returned as a JSON object and formatted for consumption by Terraform",
 				Action: func(c *cli.Context) error {


### PR DESCRIPTION
Fixes tonedefdev/terracreds#3. Also ran `gofmt -s -w .`, hence the removals of the unneeded `&cli.Command` struct type qualifiers.