### PR TITLE
Support for terraform login/logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 <img src="https://github.com/tonedefdev/terracreds/blob/main/img/terracreds.png?raw=true" align="right" width="350" height="350">
 
 # Terracreds
-A credential helper for Terraform Cloud/Enterprise that allows secure storage of your API token within the operating system's vault instead of in a plain text configuration file. Storing secrets in plain text can pose major security threats, and Terraform doesn't come pre-packaged with a credential helper, so we decided to create one and to share it with the greater Terraform/DevOps community to help enable stronger security practices.
+A credential helper for Terraform Cloud/Enterprise that allows secure storage of your API token within the operating system's vault instead of in a plain text configuration file. 
+
+We all know storing secrets in plain text can pose major security threats, and Terraform doesn't come pre-packaged with a credential helper, so we decided to create one and to share it with the greater Terraform/DevOps community to help enable stronger security practices.
 
 #### Currently supported Operating Systems:
 - [x] Windows (Credential Manager)
@@ -14,12 +16,12 @@ A credential helper for Terraform Cloud/Enterprise that allows secure storage of
 
 ## Windows Install via Chocolatey
 The fastest way to install `terracreds` on Windows is via our Chocolatey package:
-```shell
+```bash
 choco install terracreds -y
 ```
 
 Once installed run the following command to verify `terracreds` was installed properly:
-```shell
+```bash
 terracreds -v
 ```
 ## macOS Install
@@ -31,26 +33,36 @@ Download the source files by entering the following command:
 go get github.com/tonedefev/terracreds 
 ```
 
-Once the files have been downloaded navigate to the `terracreds` directory and then run:
+Ensure you have the environment variable `GO111MODULE` enabled since this project leverages `go.mod`
+
+For Windows:
+```powershell
+$env:GO111MODULE='on'
+```
+
+For macOS:
+```bash
+export GO111MODULE='on'
+```
+
+Once the files have been downloaded navigate to the `terracreds` directory in the and then run:
 ```go
 go install -v
 ```
 
-Navigate to the `bin` directory and you should see the `terracreds.exe` binary for Windows or `terracreds` for macOS. On Windows, copy the `.exe` to any directory of your choosing. Be sure to add the directory on `$env:PATH` for Windows to make using the application easier. On macOS we recommend you place the binary in `/usr/bin` as this directory should already be on the `$PATH` environment variable.
+Navigate to the root of the project directory and you should see the `terracreds.exe` binary for Windows or `terracreds` for macOS. On Windows, copy the `.exe` to any directory of your choosing. Be sure to add the directory on `$env:PATH` for Windows to make using the application easier. On macOS we recommend you place the binary in `/usr/bin` as this directory should already be on the `$PATH` environment variable.
 
 ## Initial Configuration
 In order for `terracreds` to act as your credential provider you'll need to generate the binary and the plugin directory in the default location that Terraform looks for plugins. Specifically, for credential helpers, and for Windows, the directory is `%APPDATA%\terraform.d\plugins` and for macOS `$HOME/.terraformrc`
 
 To make things as simple as possible we created a helper command to generate everthing needed to use the app. All you need to do is run the following command in `terracreds` to generate the plugin directory, and the correctly formatted binary that Terraform will use:
-```shell
+```bash
 terracreds generate
 ```
 
 This command will generate the binary as `terraform-credentials-terracreds.exe` for Windows or `terraform-credentials-terracreds` for macOS which is the valid naming convention for Terraform to recognize this plugin as a credential helper.
 
 In addition to the binary and plugin a `terraform.rc` file is required for Windows or `.terraformrc` for macOS with a `credentials_helper` block which instructs Terraform to use the specified credential helper. If you don't already have a `terraform.rc` or a `.terraformrc` file you can pass in `--create-cli-config` to create the file with the credentials helper block already generated for use with the `terracreds` binary for your OS.
-
-> **IMPORTANT NOTE**: If you're running a version of Terraform 0.11 or older on `Windows` you'll need to pass in `--windows-legacy-cli-config` instead of `--create-cli-config` as the directory where Terraform looks for the `terraform.rc` file changed with version Terraform 0.12 and newer. In Terraform 0.11 the binary looks for this file in `%APPDATA%\terraform.rc` instead of `%APPDATA%\terraform.d\terraform.rc`
 
 However, if you already have a `terraform.rc` or `.terraformrc` file you will need to add the following block to your file instead:
 
@@ -62,44 +74,36 @@ credentials_helper "terracreds" {
 
 Once you have moved all of your tokens from this file to the `Windows Credential Manager` or `KeyChain` via `terracreds` you can remove the tokens from the file. If you don't remove the tokens, and you add the `credentials_helper` block to this file, Terraform will still use the tokens instead of `terracreds` to retreive the tokens, so be sure to remove your tokens from this file once you have used the `create` command to create the credentials in `terracreds` so you can actually leverage the credential helper.
 
-The last configuration step is specific to Windows. You will need to add a Terraform environment variable that points to the path fo the `terraform.rc` file. Terraform's documentation states that on Windows the default location is `%APPDATA%\terraform.d\` however in our testing this wasn't the case. You can set the environment variable one of two ways:
-
-Add the following to your PowerShell profile (`Microsoft.PowerShell_profile.ps1`) to persist this environment variable each time a PowerShell session is launched:
-```powershell
-$env:TF_CLI_CONFIG_FILE="$($env:APPDATA)\terraform.d\terraform.rc"
-```
-
-Manually add the environment variable as a user variable by navigating to `Control Panel > All Control Panel Items > System > Advanced system settings > Environment variables... > User variables > New...` then enter:
-
-```txt
-Variable name: TF_CLI_CONFIG_FILE
-Variable value: %APPDATA%\terraform.d\terraform.rc
-```
-
 ## Storing Credentials
-For Terraform to properly use the credentials stored in your credential manager they need to be stored a specific way. The name of the credential object must be the domain name of the Terraform Cloud or Enterprise server. For instance `my.terraform.com`
+For Terraform to properly use the credentials stored in your credential manager they need to be stored a specific way. The name of the credential object must be the domain name of the Terraform Cloud or Enterprise server. For instance `app.terraform.io` which is the default name `terraform login` will use.
 
 The value for the password will correspond to the API token associated for that specific Terraform Cloud or Enterprise server.
 
-To store the credentials you'll need to run the following command:
-```shell
-terracreds create -n my.terraform.com -t yourAPITokenString
+The entire process is kicked off directly from the Terraform CLI. Run `terraform login` to start the login process with Terraform Cloud. If you're using Terraform Enterprise you'll need to pass the hostname of the server as an additional argument `terraform login my.tfe.com`
+
+You'll be sent to your Terraform Cloud instance where you'll be requested to sign-in with your account, and then sent to create an API token. Create the API token with any name you'd like for this example we'll use `terracreds`
+
+Once completed, copy the generated token, paste it into your terminal, and then hit enter. Terraform will then leverage `terracreds` to store the credentials in the operating system's credential manager. If all went well you should receive the following success message:
+
+```bash
+Success! Terraform has obtained and saved an API token.
 ```
 
-If all went well you should receive a success message:
-```
-SUCCESS: Created the credential object 'my.terraform.com'
+In the background `terraform` calls `terracreds` as its credential helper, `terraform` passes in a JSON token credential object, and then `terracreds` decodes that object from STDIN for storage in the operating system's credential manager. The following command is what is called by `terraform` during this process:
+
+```bash
+terraform-credentials-terracreds store app.terraform.io
 ```
 
 ## Verifying Credentials
 When Terraform leverages `terracreds` as the credential provider it will run the following command to get the credentials value:
-```shell
-terraform-credentials-terracreds get my.terraform.com
+```bash
+terraform-credentials-terracreds get app.terraform.io
 ```
 
 Alternatively, you can run the same command using either binary to return the credentials. The response is formatted as a JSON object as required by Terraform to use the token:
 ```powershell
-terracreds get my.terraform.com
+terracreds get app.terraform.io
 ```
 
 Example output:
@@ -108,21 +112,32 @@ Example output:
 ```
 
 ## Updating Credentials
-To update a credential simply run the same create command and it will update the token instead:
-```shell
-terracreds create -n my.terraform.com -t reallybignewtoken
-```
+To update a credential in your credential manager simply go through the same `terraform login` process and it will generate a new token and save it for you!
 
 If the token was updated successfully the following message is returned:
-```
-SUCCESS: Updated the credential object 'my.terraform.com'
+```bash
+Success! Terraform has obtained and saved an API token.
 ```
 
-## Deleting Credentials
+Additionally, you can check the `terracreds.log` if logging is enabled for more information.
+
+## Forgetting Credentials
 You can delete the credential object at any time by running:
-```shell
-terracreds delete -n my.terraform.com
+```bash
+terraform logout
 ```
+
+In the background `terraform` calls `terracreds` to perform:
+```bash
+terracreds forget app.terraform.io
+```
+
+If the credential was successfully deleted `terraform` will return:
+```text
+Success! Terraform has removed the stored API token for app.terraform.io.
+```
+
+Additionally, you can check the `terracreds.log` if logging is enabled for more information.
 
 ## Protection
 In order to add some protection `terracreds` adds a username to the credential object, and checks to ensure that the user requesting access to the token is the same user as the token's creator. This means that only the user account used to create the token can view the token from `terracreds` which ensures that the token can only be read by the account used to create it. Any attempt to access or modify this token from `terracreds` outside of the user that created the credentail will lead to denial messages. Additionally, if the credential name is not found, the same access denied message will be provided in lieu of a generic not found message to help prevent brute force attempts.
@@ -145,4 +160,4 @@ logging:
   path: /usr/
 ```
 
-The log will be located at the defined path as `terracreds.log` 
+The log is helpful in understanding if an object was found, deleted, updated or added, and will be found at the path defined in the configuration file as `terracreds.log`


### PR DESCRIPTION
In order to support `terraform login/logout` the entire application had to be redesigned:

- Removed the `create` and `delete` flags entirely since we can now leverage `terraform` to do the heavy lifting
- Renamed `create` to `store` and `delete` to `forget` to allow `terraform` to handle these actions
- Store now reads from STDIN, decodes the JSON token passed in, and then stores it in the credential manager. This can no longer be used on its own since it reads from STDIN
- Removed the `--windows-legacy-cli-config` while debugging it was discovered this path is not legacy but the actual path
- Updated readme to include all the changes

Since this will introduce a lot of breaking changes I'm proposing we release as minor version `1.1.0`

This resolves #3 