### PR TITLE
fix: Change config and log file permissions

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -134,7 +134,7 @@ func WriteToFile(filename string, data string) error {
 // WriteToLog will create a log if it doesn't exist and then append
 // messages to the log
 func WriteToLog(path string, data string, level string) error {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func CreateConfigFile(path string) error {
 			}
 
 			bytes, err := yaml.Marshal(&cfgFile)
-			err = ioutil.WriteFile(path, bytes, 0755)
+			err = ioutil.WriteFile(path, bytes, 0644)
 			if err != nil {
 				return err
 			}
@@ -189,7 +189,7 @@ func WriteConfig(path string, cfg *api.Config) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(path, bytes, 0755)
+	err = ioutil.WriteFile(path, bytes, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have (attempted) to amend the permissions on the functions that create files to 0644, so they aren't world executable.