### PR TITLE
Version 2.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terracreds
 terracreds.json
+config.yaml

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We all know storing secrets in plain text can pose major security threats, and T
 ## Windows Install via Chocolatey
 The fastest way to install `terracreds` on Windows is via our Chocolatey package:
 ```powershell
-choco install terracreds --version "2.1.0" -y
+choco install terracreds -y
 ```
 
 Once installed run the following command to verify `terracreds` was installed properly:
@@ -65,21 +65,27 @@ terracreds -v
 
 To upgrade `terracreds` to the latest version with Chocolatey run the the following command:
 ```powershell
-choco upgrade terracreds --version "2.1.0" -y
+choco upgrade terracreds -y
 ```
 
 ## macOS Install
-We are currently working on a `homebrew` package, however, to install the package simply download our latest release from this repository, 
-extract the package, and then place it in a directory available on `$HOME`.
+We are currently working on a `homebrew` package, however, you can leverage this shell script to install `terracreds`
+
+```sh
+curl https://github.com/tonedefdev/terracreds/releases/download/v2.1.2/terracreds_2.1.2_darwin_amd64.tar.gz -o terracreds_2.1.2_darwin_amd64.tar.gz  && \
+tar -xvf terracreds_2.1.2_darwin_amd64.tar.gz && \
+sudo mv -f terracreds /usr/bin/terracreds && \
+rm -f terracreds_2.1.2_darwin_amd64.tar.gz README.md
+```
 
 ## Linux Install
 You'll need to download the latest binary from our release page and place it anywhere on `$PATH` of your system. You can also copy and run the following commands:
 
 ```bash
-wget https://github.com/tonedefdev/terracreds/releases/download/v2.1.0/terracreds_2.1.0_linux_amd64.tar.gz && \
-tar -xvf terracreds_2.1.0_linux_amd64.tar.gz && \
+wget https://github.com/tonedefdev/terracreds/releases/download/v2.1.2/terracreds_2.1.2_linux_amd64.tar.gz && \
+tar -xvf terracreds_2.1.2_linux_amd64.tar.gz && \
 sudo mv -f terracreds /usr/bin/terracreds && \
-rm -f terracreds_2.1.0_linux_amd64.tar.gz README.md
+rm -f terracreds_2.1.2_linux_amd64.tar.gz README.md
 ```
 
 The `terracreds` Linux implementation uses `gnome-keyring` in conjunction with `gnome-keyring-daemon` 

--- a/README.md
+++ b/README.md
@@ -405,9 +405,8 @@ export TC_CONFIG_PATH=/home/username/
 
 For Windows:
 ```powershell
-$env:TC_CONFIG_PATH="C:\Temp\"
+$env:TC_CONFIG_PATH="C:\Temp"
 ```
-> Please, take note of the trailing slash!
 
 To persist this change you can set this variables either in `.bashrc` for Linux/macOS or setup a PowerShell profile for Windows.
 
@@ -415,19 +414,19 @@ To enable logging for Windows setup the `config.yaml` as follows:
 ```yaml
 logging:
   enabled: true
-  path: C:\Temp\
+  path: C:\Temp
 ```
 
-To enable logging for macOS and Linux:
+To enable logging for macOS and Linux to a directory called `.terracreds` in the user's home profile:
 ```yaml
 logging:
   enabled: true
-  path: /home/username/
+  path: ~/.terracreds
 ```
 
 You can also use `terracreds` to configure logging:
 ```bash
-terracreds config logging --path '/home/username/' --enabled
+terracreds config logging --path '~/.terracreds' --enabled
 ```
 
 The log is helpful in understanding if an object was found, deleted, updated or added, and will be found at the path defined in the configuration file as `terracreds.log`.

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -20,7 +21,7 @@ import (
 
 const (
 	cfgName = "config.yaml"
-	version = "2.1.0"
+	version = "2.1.2"
 )
 
 var (
@@ -123,10 +124,10 @@ func NewTerraVault(cfg *api.Config, hostname string) vault.TerraVault {
 func main() {
 	fileEnvVar := os.Getenv("TC_CONFIG_PATH")
 	if fileEnvVar != "" {
-		configFilePath = fileEnvVar + cfgName
+		configFilePath = filepath.Join(fileEnvVar, cfgName)
 	} else {
 		binPath := helpers.GetBinaryPath(os.Args[0], runtime.GOOS)
-		configFilePath = binPath + cfgName
+		configFilePath = filepath.Join(binPath, cfgName)
 	}
 
 	err := helpers.CreateConfigFile(configFilePath)
@@ -148,7 +149,7 @@ func main() {
 	app := &cli.App{
 		Name:      "terracreds",
 		Usage:     "a credential helper for Terraform Automation and Collaboration Software (TACOS) that leverages your vault provider of choice for securely storing API tokens or other secrets.\n\n   Visit https://github.com/tonedefdev/terracreds for more information",
-		UsageText: "Store Terraform Automation and Collaboration Software API tokens by running 'terraform login' or manually store them using 'terracreds create -n app.terraform.io -v myAPItoken'",
+		UsageText: "Store Terraform Enterprise or Cloud API tokens by running 'terraform login' or manually store any secret you choose with 'terracreds create -n mySuperSecret -v mySuperSafePassword'",
 		Version:   version,
 		Commands: []*cli.Command{
 			{
@@ -468,7 +469,7 @@ func main() {
 			{
 				Name:    "create",
 				Aliases: []string{"update"},
-				Usage:   "Manually create or update a credential object in the vault provider of your choice that contains either the Terraform Automation and Collaboration Software API's authorization token or another secret",
+				Usage:   "Manually create or update a credential object in the vault provider of your choice that contains either the Terraform Enterprise or Cloud API token or any other type of secret",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:    "name",
@@ -505,7 +506,7 @@ func main() {
 			},
 			{
 				Name:  "delete",
-				Usage: "Delete a stored credential in the vault provider of your choice",
+				Usage: "Delete a stored credential in the vault",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:    "name",
@@ -544,7 +545,7 @@ func main() {
 			},
 			{
 				Name:  "forget",
-				Usage: "(Terraform Only) Forget a stored credential in your vault provider of choice when 'terraform logout' has been called",
+				Usage: "(Terraform Only) Forget a stored credential in your vault when 'terraform logout' has been called",
 				Action: func(c *cli.Context) error {
 					if len(os.Args) == 2 {
 						fmt.Fprintf(color.Output, "%s: No secret name was specified. Use 'terracreds forget -h' for help info\n", color.RedString("ERROR"))
@@ -583,7 +584,7 @@ func main() {
 			},
 			{
 				Name:  "get",
-				Usage: "Get the credential object value by passing the hostname of the Terraform Automation and Collaboration Software server's hostname or the name of the secret as an argument. The credential is returned as a JSON object and formatted for consumption by Terraform",
+				Usage: "Get the credential object value by passing the server's hostname (Terraform backend default behavior) or the name of the secret as an argument. The credential is returned as a JSON object and formatted for consumption by Terraform",
 				Action: func(c *cli.Context) error {
 					if len(os.Args) > 2 {
 						user, err := user.Current()
@@ -628,7 +629,7 @@ func main() {
 					&cli.BoolFlag{
 						Name:     "as-tfvars",
 						Value:    false,
-						Usage:    "Exports the secret keys and values as 'TF_VARS_secret_key=secret_value' for the given operating system",
+						Usage:    "Prints the secret keys and values as 'TF_VARS_secret_key=secret_value'",
 						Required: false,
 					},
 					&cli.BoolFlag{
@@ -718,7 +719,7 @@ func main() {
 			},
 			{
 				Name:  "store",
-				Usage: "(Terraform Only) Store or update a Terraform Automation and Collaboration Software API token in your vault provider of choice when 'terraform login' has been called",
+				Usage: "(Terraform Only) Store or update a Terraform Enterprise or Cloud API token in your vault provider of choice when 'terraform login' has been called",
 				Action: func(c *cli.Context) error {
 					if len(os.Args) == 2 {
 						fmt.Fprintf(color.Output, "%s: No hostname was specified. Use 'terracreds store -h' to print help info\n", color.RedString("ERROR"))

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -245,7 +245,7 @@ func GenerateTerraCreds(c *cli.Context, version string, confirm string) error {
 
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		userProfile := os.Getenv("HOME")
-		cliConfig = filepath.Join(userProfile, ".terraform.d", ".terraformrc")
+		cliConfig = filepath.Join(userProfile, ".terraformrc")
 		tfPlugins = filepath.Join(userProfile, ".terraform.d", "plugins")
 		binary = filepath.Join(tfPlugins, "terraform-credentials-terracreds")
 	}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -6,11 +6,13 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/fatih/color"
+	"github.com/mitchellh/go-homedir"
 	"github.com/tonedefdev/terracreds/api"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
@@ -201,7 +203,12 @@ func WriteConfig(path string, cfg *api.Config) error {
 // Logging forms the path and writes to log if enabled
 func Logging(cfg api.Config, msg string, level string) {
 	if cfg.Logging.Enabled == true {
-		logPath := cfg.Logging.Path + "terracreds.log"
+		absolutePath, err := homedir.Expand(cfg.Logging.Path)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		logPath := filepath.Join(absolutePath, "terracreds.log")
 		WriteToLog(logPath, msg, LogLevel(level))
 	}
 }
@@ -230,17 +237,17 @@ func GenerateTerraCreds(c *cli.Context, version string, confirm string) error {
 	var binary string
 
 	if runtime.GOOS == "windows" {
-		userProfile := os.Getenv("USERPROFILE")
-		cliConfig = userProfile + "\\AppData\\Roaming\\terraform.rc"
-		tfPlugins = userProfile + "\\AppData\\Roaming\\terraform.d\\plugins"
-		binary = fmt.Sprintf("%s\\terraform-credentials-terracreds.exe", tfPlugins)
+		userProfile := filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Roaming")
+		cliConfig = filepath.Join(userProfile, "terraform.rc")
+		tfPlugins = filepath.Join(userProfile, "terraform.d", "plugins")
+		binary = filepath.Join(tfPlugins, "terraform-credentials-terracreds.exe")
 	}
 
 	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
 		userProfile := os.Getenv("HOME")
-		cliConfig = userProfile + "/.terraform.d/.terraformrc"
-		tfPlugins = userProfile + "/.terraform.d/plugins"
-		binary = fmt.Sprintf("%s/terraform-credentials-terracreds", tfPlugins)
+		cliConfig = filepath.Join(userProfile, ".terraform.d", ".terraformrc")
+		tfPlugins = filepath.Join(userProfile, ".terraform.d", "plugins")
+		binary = filepath.Join(tfPlugins, "terraform-credentials-terracreds")
 	}
 
 	err := NewDirectory(tfPlugins)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -34,7 +34,7 @@ func CopyTerraCreds(dest string) error {
 	}
 	defer from.Close()
 
-	to, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE, 0755)
+	to, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func GetBinaryPath(binary string, os string) string {
 func NewDirectory(path string) error {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			err := os.Mkdir(path, 0755)
+			err := os.Mkdir(path, 0644)
 			if err != nil {
 				return err
 			}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,7 @@ variable "location" {
 
 variable "keyvault_only" {
   type        = bool
-  default     = true
+  default     = false
   description = "Create only the Azure Key Vault resources and not any VMs"
 }
 


### PR DESCRIPTION
- Added tilde expansion so that tildes in the config file can be used. Closes #15 
- Ensuring that all files/directories made by `terracreds` set mode to `0644`. Thanks @chris3ware for the initial PR and contribution!
- Leveraging `path.filepath` standard library instead of constructing paths manually
- Updated the README to include some of these changes